### PR TITLE
Fix/remove view hint

### DIFF
--- a/components/QuestCard.tsx
+++ b/components/QuestCard.tsx
@@ -98,10 +98,9 @@ export default function QuestCard({ title, points, description, hint, id, url, a
       </div>
       
       {/* Hint Section (Expandable) */}
-      <details className="mt-4" open={isHintVisible}>
-        <summary className="cursor-pointer text-green-500">View Hint</summary>
+      <div className={"mt-4 transition-all duration-300 max-h-fit"} style={{ maxHeight: isHintVisible ? '600px' : '0', overflow: 'hidden' }}>
         <p className="text-green-300 text-sm mt-2">{hint}</p>
-      </details>
+      </div>
       
       {/* Flag Submission */}
       <form onSubmit={handleSubmit} className="mt-4">


### PR DESCRIPTION
Closes #2 

## Description
- Made changes to the togglable view hint heading and now there is no redundancy
- I had to check by bypassing the Auth as Login wasn't working even after Auth for some reason both in the official website and my PC even after setting .env
- Also wanted to ask, should I add something like "Hint: ..." in place of only hint ?

## Preview

| Before | After |
|------|----|
| ![image](https://github.com/user-attachments/assets/4e3c1e65-688d-440b-918c-8c61c6a79a3c) | ![image](https://github.com/user-attachments/assets/c877ee41-b9c1-4f84-9d15-da1f3410ed1e) |
| ![image](https://github.com/user-attachments/assets/f25f90bb-42f4-4fa2-abdd-174830c360dc) | ![image](https://github.com/user-attachments/assets/f4172e49-29b6-4ff9-b009-4a85ae021231) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the expandable hint section to improve visual consistency and control when toggling hint visibility, providing a smoother and more reliable display experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->